### PR TITLE
Re-add disable for button after press

### DIFF
--- a/www/templates/user-profile.html
+++ b/www/templates/user-profile.html
@@ -1,7 +1,7 @@
 <ion-view title="user-profile">
 
   <div class="bar bar-subheader" id="option-notification" ng-hide="pageExtended">
-    <button class="button button-calm invite-button" ng-click="sendInvitation(displayUser.objectId)">Invite to meet up!</button>
+    <button class="button button-calm invite-button" ng-click="sendInvitation(displayUser.objectId)" ng-disabled="inviteDisabled">Invite to meet up!</button>
   </div>
 
   <ion-content  class="has-header has-footer" id="ion-user-profile">


### PR DESCRIPTION
For some reason this got removed during one of the merges. It makes sure that the invite button is properly disabled after pressing it.
